### PR TITLE
Remove some bug

### DIFF
--- a/src/main/java/org/junit/internal/runners/JUnit38ClassRunner.java
+++ b/src/main/java/org/junit/internal/runners/JUnit38ClassRunner.java
@@ -72,7 +72,7 @@ public class JUnit38ClassRunner extends Runner implements Filterable, Orderable 
         }
     }
 
-    private volatile Test test;
+    private  Test test;
 
     public JUnit38ClassRunner(Class<?> klass) {
         this(new TestSuite(klass.asSubclass(TestCase.class)));

--- a/src/main/java/org/junit/runner/Description.java
+++ b/src/main/java/org/junit/runner/Description.java
@@ -156,7 +156,7 @@ public class Description implements Serializable {
     private final String fDisplayName;
     private final Serializable fUniqueId;
     private final Annotation[] fAnnotations;
-    private volatile /* write-once */ Class<?> fTestClass;
+    private  /* write-once */ Class<?> fTestClass;
 
     private Description(Class<?> clazz, String displayName, Annotation... annotations) {
         this(clazz, displayName, displayName, annotations);

--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -72,9 +72,9 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
     private final TestClass testClass;
 
     // Guarded by childrenLock
-    private volatile List<T> filteredChildren = null;
+    private  List<T> filteredChildren = null;
 
-    private volatile RunnerScheduler scheduler = new RunnerScheduler() {
+    private  RunnerScheduler scheduler = new RunnerScheduler() {
         public void schedule(Runnable childStatement) {
             childStatement.run();
         }


### PR DESCRIPTION
Bug correction : 

	src/main/java/org/junit/internal/runners/JUnit38ClassRunner.java : 
		- Remove keyword "volatile" on "private volatile Test test" declaration. This could be a bug sources in the future
		
	src/main/java/org/junit/runner/Description.java :
		- Remove keyword "volatile" on "private volatile Class<?> fTestClass" declaration. This could be a bug sources in the future
		
	src/main/java/org/junit/runners/ParentRunner.java :
		- Remove keyword "volatile" on "private volatile List<T> filteredChildren = null;" declaration. This could be a bug sources in the future
		- Remove keyword "volatile" on "private volatile RunnerScheduler scheduler" declaration. This could be a bug sources in the future